### PR TITLE
Ihor branch

### DIFF
--- a/pandoc/README.md
+++ b/pandoc/README.md
@@ -1,5 +1,5 @@
 # Pandoc conversion notes
-
+# modified for test commit
 ## 1. Pandoc conversion command
 
 Edit ```data-dir``` in ```pandoc/options.yml```. Something like:

--- a/pandoc/README.md
+++ b/pandoc/README.md
@@ -1,5 +1,5 @@
 # Pandoc conversion notes
-# modified for test commit
+
 ## 1. Pandoc conversion command
 
 Edit ```data-dir``` in ```pandoc/options.yml```. Something like:

--- a/pandoc/css/pandoc.css
+++ b/pandoc/css/pandoc.css
@@ -19,13 +19,8 @@ p.byline { font-size: 1.2rem; }
 
 
 /* Simulate Pandoc's table output styles */
-table {
-  border-top: 2px solid black;
-  border-bottom: 2px solid black;
-}
-th {
-  border-bottom: 1px solid black;
-}
+
+
 td, th {
   font-size: 1.4rem;
   padding: 10px;

--- a/pandoc/css/tweak.css
+++ b/pandoc/css/tweak.css
@@ -42,3 +42,7 @@ figure img {
   margin-left: auto;
   margin-right: auto;
 }
+
+li p {
+  margin: 0px;
+}

--- a/pandoc/css/tweak.css
+++ b/pandoc/css/tweak.css
@@ -17,3 +17,7 @@ table {
   width: 90%;
   overflow-x: visible;
 }
+
+h5 {
+  font-size: 1.5em;
+}

--- a/pandoc/css/tweak.css
+++ b/pandoc/css/tweak.css
@@ -22,8 +22,12 @@ table, th, td {
   border-collapse: collapse;
 }
 h5 {
-  font-size: 1.5em;
+  font-size: 1.4em;
 }
+h4 {
+  font-size: 1.6em;
+}
+
 
 .chapsumm, .lookbox {
   background-color: rgb(247, 247, 225);

--- a/pandoc/css/tweak.css
+++ b/pandoc/css/tweak.css
@@ -32,3 +32,9 @@ h5 {
   margin-left: 5%;
   margin-right: 5%;
 }
+
+figure img {
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/pandoc/css/tweak.css
+++ b/pandoc/css/tweak.css
@@ -21,3 +21,11 @@ table {
 h5 {
   font-size: 1.5em;
 }
+
+.chapsumm, .lookbox {
+  background-color: rgb(247, 247, 225);
+  padding: 10px;
+  width: 40%;
+  margin-left: 5%;
+  margin-right: 5%;
+}

--- a/pandoc/css/tweak.css
+++ b/pandoc/css/tweak.css
@@ -46,3 +46,10 @@ figure img {
 li p {
   margin: 0px;
 }
+pre  {
+  width: 100% !important;
+  white-space: normal;
+}
+pre code {
+  white-space: normal;
+}

--- a/pandoc/css/tweak.css
+++ b/pandoc/css/tweak.css
@@ -14,10 +14,13 @@ td {
   white-space: nowrap;
 }
 table {
-  width: 90%;
+  min-width: 55%;
   overflow-x: visible;
 }
-
+table, th, td {
+  border: 1px solid black;
+  border-collapse: collapse;
+}
 h5 {
   font-size: 1.5em;
 }

--- a/pandoc/tufte/tufte.css
+++ b/pandoc/tufte/tufte.css
@@ -204,16 +204,17 @@ figure {
 }
 
 figcaption {
-    float: right;
     clear: right;
-    margin-top: 0;
-    margin-bottom: 0;
     font-size: 1.1rem;
     line-height: 1.6;
     vertical-align: baseline;
-    position: relative;
-    max-width: 40%;
+    max-width: 90%;
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 1em;
 }
+
 
 figure.fullwidth figcaption {
     margin-right: 24%;


### PR DESCRIPTION
Fixed the size of chapsumm and lookbox classes.
Set the margin-left and margin-right to 5%.
Set the width same as the text.